### PR TITLE
ctdump shell add 2 variants

### DIFF
--- a/configtree/formatter.py
+++ b/configtree/formatter.py
@@ -23,7 +23,7 @@ from pkg_resources import iter_entry_points
 from numbers import Number
 
 from .tree import rarefy
-from .compat.types import string, chars, basestr
+from .compat.types import string, chars
 from .compat.colabc import Mapping, Sequence
 
 
@@ -189,13 +189,18 @@ def to_shell(tree, prefix="", seq_sep=" ", sort=False, capitalize=False, capsboo
             return string(value).upper() if capsbool else string(value).lower()
         if isinstance(value, Number):
             return string(value)
-        # NOTE : https://stackoverflow.com/a/16605140
-        #        https://stackoverflow.com/a/1250279
-        if isinstance(value, basestr):
-            return u"""'%s'""" % string(value).replace("""'""","""'"'"'""")
-            
+        if isinstance(value, Sequence) and not isinstance(value, chars):
+            print("value")
+            print(value)
+            if(isinstance(value,tuple)):
+                return u"'(%s)'" % ", ".join(
+                    string(item).replace("""'""","""'"'"'""") for item in value
+                )
+            else:
+                return u"'[%s]'" % ", ".join(
+                    string(item).replace("""'""","""'"'"'""") for item in value
+                )
         return u"""'%s'""" % string(value).replace("""'""","""'"'"'""")
-
 
     result = []
 

--- a/docs/advanced_usage.rst
+++ b/docs/advanced_usage.rst
@@ -521,25 +521,116 @@ You can build only a part of configuration specifying branch:
     ctdump json --path path/to/config/sources --branch app.http > path/to/build/server.json
     ctdump json --path path/to/config/sources --branch app.db > path/to/build/database.json
 
+For shell output you have the choice between several formats:
+
+..  code-block:: yaml
+
+
+        string1: 'foo bar'
+        string2: '"foo" bar'
+        string3: '\"foo\" bar'
+        string4: "'foo' bar"
+        string5: "\\'foo\\' bar"
+        a: '[2, 3]'
+        b: '(2, 3)'
+        c: '1'
+        d: 1
+        e: (2, 3)
+        f: [4, 5]
+        g: 'Testing "G"'
+        h: 'Testing \"G\"'
+        i: "Testing 'I'"
+        j: "Testing \\'J\\'"
+        k: [4, 5, [10,11]]
+
+The default format and the historic default one `legacy`, it may have problem with escaping some characters:
+
+..  code-block::  Bash
+
+        ctdump shell --shell-form=legacy
+        # Output of ctdump will look like this:
+        # string1='foo bar'
+        # string2='"foo" bar'
+        # string3='\"foo\" bar'
+        # string4='\'foo\' bar'
+        # string5='\\'foo\\' bar'
+        # a='[2, 3]'
+        # b='(2, 3)'
+        # c='1'
+        # e='(2, 3)'
+        # f='4 5'
+        # g='Testing "G"'
+        # h='Testing \"G\"'
+        # i='Testing \'I\''
+        # j='Testing \\'J\\''
+        # k='4 5 [10, 11]'
+
+The format `form1`, which is more robust to escape quotes:
+
+..  code-block::  Bash
+
+        ctdump shell --shell-form=form1
+        # Output of ctdump will look like this:
+        # string1='foo bar'
+        # string2='"foo" bar'
+        # string3='\"foo\" bar'
+        # string4=''"'"'foo'"'"' bar'
+        # string5='\'"'"'foo\'"'"' bar'
+        # a='[2, 3]'
+        # b='(2, 3)'
+        # c='1'
+        # e='(2, 3)'
+        # f='4 5'
+        # g='Testing "G"'
+        # h='Testing \"G\"'
+        # i='Testing '"'"'I'"'"''
+        # j='Testing \'"'"'J\'"'"''
+        # k='4 5 [10, 11]'
+
+
+The format `form2`, which is equaly robust to quotes, but do not transform
+`python list [a, b]` into a separated string:
+
+..  code-block::  Bash
+
+        ctdump shell --shell-form=form1
+        # string1='foo bar'
+        # string2='"foo" bar'
+        # string3='\"foo\" bar'
+        # string4=''"'"'foo'"'"' bar'
+        # string5='\'"'"'foo\'"'"' bar'
+        # a='[2, 3]'
+        # b='(2, 3)'
+        # c='1'
+        # e='(2, 3)'
+        # f='[4, 5]'
+        # g='Testing "G"'
+        # h='Testing \"G\"'
+        # i='Testing '"'"'I'"'"''
+        # j='Testing \'"'"'J\'"'"''
+        # k='[4, 5, [10, 11]]'
+
+
 The special formatter for shell scripts helps to use configuration within Bash scripts.
 For example, you want to use database credentials:
 
 ..  code-block:: yaml
 
         username: 'dbuser'
-        x: 1
-        t: (2, 3)
-        l: [4, 5]
+        password: 'qwerty'
+        database: 'mydata'
 
-..  code-block::  Bash    
+..  code-block::  Bash
 
-    ctdump shell --branch app.db --shell-prefix 'local '
-    # Output of ctdump will look like this:
-    #   local username='dbuser'
-    #   local x=1
-    #   local t=
-    #   local l=
+    backup_db() {
+        eval "$( ctdump shell --shell-prefix 'local ' )"
+        # Output of ctdump will look like this:
+        #   local username='dbuser'
+        #   local password='qwerty'
+        #   local database='mydata'
 
+        mysqldump --user="$username" --password="$password" "$database" > dump.sql
+    }
 
 To get full help of the command run:
 

--- a/docs/advanced_usage.rst
+++ b/docs/advanced_usage.rst
@@ -453,7 +453,7 @@ formatters.  This formatters are used by :ref:`ctdump` to print result.
 The following formats are supported out of the box:
 
 *   JSON with name ``json`` by :func:`configtree.formatter.to_json`;
-*   Shell script (Bash) with name ``shell`` by :func:`configtree.formatter.to_shell`.
+*   Shell script (Bash) with name ``shell`` into different format possible by :func:`configtree.formatter.to_shell`.
 
 The map is filled scanning `entry points`_ ``configtree.formatters``.  So that it is
 extensible by plugins.  Ad hoc formatter can be also defined within :ref:`loaderconf_py`
@@ -524,17 +524,22 @@ You can build only a part of configuration specifying branch:
 The special formatter for shell scripts helps to use configuration within Bash scripts.
 For example, you want to use database credentials:
 
-..  code-block::  Bash
+..  code-block:: yaml
 
-    backup_db() {
-        eval "$( ctdump shell --branch app.db --shell-prefix 'local ' )"
-        # Output of ctdump will look like this:
-        #   local username='dbuser'
-        #   local password='qwerty'
-        #   local database='mydata'
+        username: 'dbuser'
+        x: 1
+        t: (2, 3)
+        l: [4, 5]
 
-        mysqldump --user="$username" --password="$password" "$database" > dump.sql
-    }
+..  code-block::  Bash    
+
+    ctdump shell --branch app.db --shell-prefix 'local '
+    # Output of ctdump will look like this:
+    #   local username='dbuser'
+    #   local x=1
+    #   local t=
+    #   local l=
+
 
 To get full help of the command run:
 

--- a/tests/test_formatter.py
+++ b/tests/test_formatter.py
@@ -101,12 +101,12 @@ def test_shell():
     result = [line.rstrip() for line in result.split(linesep)]
     assert result == [
         "local A_U='\\'",
-        'local A_V=\'(\'"\'"\'a\'"\'"\', \'"\'"\'b\'"\'"\')\'',
+        "local A_V='(a, b)'",
         """local A_X=1""",
         """local A_Y='Testing "json"'""",
         'local A_Z=\'Testing \'"\'"\'shell\'"\'"\'\'',
         "local BOOL=TRUE",
-        'local LIST=\'[\'"\'"\'Testing "json"\'"\'"\', "Testing \'"\'"\'shell\'"\'"\'"]\'',
+        'local LIST=\'[Testing "json", Testing \'"\'"\'shell\'"\'"\']\'',
         "local NONE=''",
     ]
 

--- a/tests/test_formatter.py
+++ b/tests/test_formatter.py
@@ -10,6 +10,7 @@ t = Tree(
         "a.y": 'Testing "json"',
         "a.z": "Testing 'shell'",
         "a.u": "\\",
+        "a.v": ('a', 'b'),
         "list": ['Testing "json"', "Testing 'shell'"],
         "none": None,
         "bool": True,
@@ -23,6 +24,10 @@ def test_json():
     assert result == [
         "{",
         '    "a.u": "\\\\",',
+        '    "a.v": [',
+        '        "a",',
+        '        "b"',
+        '    ],',
         '    "a.x": 1,',
         '    "a.y": "Testing \\"json\\"",',
         '    "a.z": "Testing \'shell\'",',
@@ -41,6 +46,10 @@ def test_json():
         "{",
         '    "a": {',
         '        "u": "\\\\",',
+        '        "v": [',
+        '            "a",',
+        '            "b"',
+        '        ],',
         '        "x": 1,',
         '        "y": "Testing \\"json\\"",',
         '        "z": "Testing \'shell\'"',
@@ -62,6 +71,7 @@ def test_shell():
     result = [line.rstrip() for line in result.split(linesep)]
     assert result == [
         "local A_U='\\'",
+        "local A_V='a:b'",
         "local A_X=1",
         "local A_Y='Testing \"json\"'",
         "local A_Z='Testing \\'shell\\''",
@@ -76,6 +86,7 @@ def test_shell():
     result = [line.rstrip() for line in result.split(linesep)]
     assert result == [
         "local A_U='\\'",
+        "local A_V='a:b'",
         "local A_X=1",
         "local A_Y='Testing \"json\"'",
         'local A_Z=\'Testing \'"\'"\'shell\'"\'"\'\'',
@@ -90,6 +101,7 @@ def test_shell():
     result = [line.rstrip() for line in result.split(linesep)]
     assert result == [
         "local A_U='\\'",
+        'local A_V=\'(\'"\'"\'a\'"\'"\', \'"\'"\'b\'"\'"\')\'',
         """local A_X=1""",
         """local A_Y='Testing "json"'""",
         'local A_Z=\'Testing \'"\'"\'shell\'"\'"\'\'',

--- a/tests/test_formatter.py
+++ b/tests/test_formatter.py
@@ -9,6 +9,7 @@ t = Tree(
         "a.x": 1,
         "a.y": 'Testing "json"',
         "a.z": "Testing 'shell'",
+        "a.u": "\\",
         "list": ['Testing "json"', "Testing 'shell'"],
         "none": None,
         "bool": True,
@@ -21,6 +22,7 @@ def test_json():
     result = [line.rstrip() for line in result.split(linesep)]
     assert result == [
         "{",
+        '    "a.u": "\\\\",',
         '    "a.x": 1,',
         '    "a.y": "Testing \\"json\\"",',
         '    "a.z": "Testing \'shell\'",',
@@ -38,6 +40,7 @@ def test_json():
     assert result == [
         "{",
         '    "a": {',
+        '        "u": "\\\\",',
         '        "x": 1,',
         '        "y": "Testing \\"json\\"",',
         '        "z": "Testing \'shell\'"',
@@ -54,15 +57,44 @@ def test_json():
 
 def test_shell():
     result = formatter.to_shell(
-        t, prefix="local ", seq_sep=":", sort=True, capitalize=True
+        t, prefix="local ", form='legacy', seq_sep=":", sort=True, capitalize=True
     )
     result = [line.rstrip() for line in result.split(linesep)]
     assert result == [
+        "local A_U='\\'",
         "local A_X=1",
         "local A_Y='Testing \"json\"'",
         "local A_Z='Testing \\'shell\\''",
         "local BOOL=true",
         "local LIST='Testing \"json\":Testing \\'shell\\''",
+        "local NONE=''",
+    ]
+
+    result = formatter.to_shell(
+        t, prefix="local ", form='form1', seq_sep=":", sort=True, capitalize=True
+    )
+    result = [line.rstrip() for line in result.split(linesep)]
+    assert result == [
+        "local A_U='\\'",
+        "local A_X=1",
+        "local A_Y='Testing \"json\"'",
+        'local A_Z=\'Testing \'"\'"\'shell\'"\'"\'\'',
+        "local BOOL=true",
+        'local LIST=\'Testing "json":Testing \'"\'"\'shell\'"\'"\'\'',
+        "local NONE=''",
+    ]
+
+    result = formatter.to_shell(
+        t, prefix="local ", form='form2', sort=True, capitalize=True, capsbool=True
+    )
+    result = [line.rstrip() for line in result.split(linesep)]
+    assert result == [
+        "local A_U='\\'",
+        """local A_X=1""",
+        """local A_Y='Testing "json"'""",
+        'local A_Z=\'Testing \'"\'"\'shell\'"\'"\'\'',
+        "local BOOL=TRUE",
+        'local LIST=\'[\'"\'"\'Testing "json"\'"\'"\', "Testing \'"\'"\'shell\'"\'"\'"]\'',
         "local NONE=''",
     ]
 


### PR DESCRIPTION
Add two variants wich robustly escape quotes

--shell-form leacy : the historic form

--shell-form form1 : robustly escape quotes

--shell-form form2 : robustly escape quotes AND do not transform list [ a,b ] into separated string